### PR TITLE
Fixed ViewPropTypes deprecated in react-native issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Varun Kumar <varunon9@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "deprecated-react-native-prop-types": "^5.0.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.5.10",

--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -4,9 +4,9 @@ import {
   View,
   Dimensions,
   Animated,
-  ViewPropTypes,
 } from 'react-native';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import XDate from 'xdate';
 
 import {parseDate, xdateToData} from '../interface';

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -1,13 +1,13 @@
 import React, {Component} from 'react';
 import {
   View,
-  ViewPropTypes,
   ScrollView,
   Dimensions,
   ActivityIndicator,
   Platform
 } from 'react-native';
 import PropTypes from 'prop-types';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import XDate from 'xdate';
 import dateutils from '../dateutils';


### PR DESCRIPTION
ViewPropTypes was deprecated in react-native. So I import ViewPropTypes from deprecated-react-native-prop-types npm to avoid crash